### PR TITLE
fix: displayName being undefined while creating snapshot

### DIFF
--- a/src/testUtils/shallow.jsx
+++ b/src/testUtils/shallow.jsx
@@ -11,7 +11,7 @@ import {
 } from 'react-is';
 import ElementExplorer from './ElementExplorer';
 
-const getNodeName = node => node.displayName || node.name || '';
+const getNodeName = node => node?.displayName || node?.name || '';
 
 class ReactShallowRenderer {
   shallowRenderer = null;


### PR DESCRIPTION
`displayName` is `undefined` while creating a snapshot during the `enzyme` to `react-unit-test-utils` migration.

<img width="1307" alt="Screenshot 2023-12-26 at 3 58 33 PM" src="https://github.com/openedx/react-unit-test-utils/assets/88369802/fd34bcf3-89a6-4993-8592-57180c3bebce">
 