### PR TITLE
fix: empty render issue

### DIFF
--- a/src/testUtils/shallow.jsx
+++ b/src/testUtils/shallow.jsx
@@ -63,7 +63,7 @@ class ReactShallowRenderer {
 
   isEmptyRender() {
     const data = this.getRenderOutput();
-    return data === null;
+    return data === null || data === false;
   }
 
   get snapshot() {


### PR DESCRIPTION
`isEmptyRender()` always returns false, even if there is no data rendered.

![Screenshot 2024-01-03 at 11 17 29 AM](https://github.com/openedx/react-unit-test-utils/assets/88369802/d1b65c51-c445-4807-9cd8-3e5bb38a2afe)
