### PR TITLE
Add catalog-info.yaml file for release data

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'React-unit-tests-utils'
+  description: "A Python library to support React unit tests."
+spec:
+  type: 'library'

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,3 +8,4 @@ metadata:
   description: "A Python library to support React unit tests."
 spec:
   type: 'library'
+  owner: group:openedx-unmaintained

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: 'React-unit-tests-utils'
+  name: 'react-unit-test-utils'
   description: "A Python library to support React unit tests."
 spec:
   type: 'library'


### PR DESCRIPTION
Description:

Update catalog-info.yaml file for release data, as the BTR script has been updated https://github.com/openedx/repo-tools/issues/439 to read the catalog-info.yaml file if it has release data, we are updating the catalog-info file as per https://github.com/openedx/public-engineering/issues/410